### PR TITLE
builder-webpack5: expressly depend on @types/express

### DIFF
--- a/code/builders/builder-webpack5/package.json
+++ b/code/builders/builder-webpack5/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@storybook/core-webpack": "workspace:*",
+    "@types/express": "^4.17.21",
     "@types/node": "^18.0.0",
     "@types/semver": "^7.3.4",
     "browser-assert": "^1.2.1",


### PR DESCRIPTION
## What I did

Storybook uses the `express` module within this Builder, and implicitly depends on `@types/express` from `builder-vite` (and other packages in the repo). For builds which don't include those packages, typechecks which validate node_modules can fail. 

## Checklist for Contributors

### Testing

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to communicate how to test your changes -->

#### The changes in this PR are covered in the following automated tests:
- [ ] stories
- [x] unit tests (by which I mean, any automated typechecks).
- [ ] integration tests
- [ ] end-to-end tests

#### Manual testing

I made this change to a local checkout and validated that the types were still consistent. Since the @types/express package was present within `code/node_modules` _anyway_, I don't expect any need for further validation.

## Checklist for Maintainers

- [ ] When this PR is ready for testing, make sure to add `ci:normal`, `ci:merged` or `ci:daily` GH label to it to run a specific set of sandboxes. The particular set of sandboxes can be found in `code/lib/cli/src/sandbox-templates.ts`
- [ ] Make sure this PR contains **one** of the labels below:
   <details>
     <summary>Available labels</summary>

     - `bug`: Internal changes that fixes incorrect behavior.
     - `maintenance`: User-facing maintenance tasks.
     - `dependencies`: Upgrading (sometimes downgrading) dependencies.
     - `build`: Internal-facing build tooling & test updates. Will not show up in release changelog.
     - `cleanup`: Minor cleanup style change. Will not show up in release changelog.
     - `documentation`: Documentation **only** changes. Will not show up in release changelog.
     - `feature request`: Introducing a new feature.
     - `BREAKING CHANGE`: Changes that break compatibility in some way with current major version.
     - `other`: Changes that don't fit in the above categories.
   
   </details>

### 🦋 Canary release

<!-- CANARY_RELEASE_SECTION -->

This PR does not have a canary release associated. You can request a canary release of this pull request by mentioning the `@storybookjs/core` team here.

_core team members can create a canary release [here](https://github.com/storybookjs/storybook/actions/workflows/canary-release-pr.yml) or locally with `gh workflow run --repo storybookjs/storybook canary-release-pr.yml --field pr=<PR_NUMBER>`_

<!-- CANARY_RELEASE_SECTION -->
